### PR TITLE
fix: hardcode the version flag

### DIFF
--- a/axolotlsay-js/dist.toml
+++ b/axolotlsay-js/dist.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axolotlsay-js"
 description = "JavaScript port of axolotlsay"
-version = "0.10.0"
+version = "0.10.1"
 license = "MIT"
 repository = "https://github.com/axodotdev/axolotlsay-hybrid"
 binaries = ["axolotlsay-js"]

--- a/axolotlsay-js/dist.toml
+++ b/axolotlsay-js/dist.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axolotlsay-js"
 description = "JavaScript port of axolotlsay"
-version = "0.10.1"
+version = "0.10.2"
 license = "MIT"
 repository = "https://github.com/axodotdev/axolotlsay-hybrid"
 binaries = ["axolotlsay-js"]

--- a/axolotlsay-js/index.js
+++ b/axolotlsay-js/index.js
@@ -2,7 +2,11 @@
 
 const yargs = require("yargs");
 const { hideBin } = require("yargs/helpers");
-const argv = yargs(hideBin(process.argv)).argv;
+const argv = yargs(hideBin(process.argv)).version(
+  "--version",
+  "Show version number",
+  "0.10.0",
+).argv;
 
 const msg = argv.msg;
 console.log(msg);

--- a/axolotlsay-js/index.js
+++ b/axolotlsay-js/index.js
@@ -1,11 +1,19 @@
 #!/usr/bin/env bun
 
+// We do this because `require` gets rewritten to handle
+// bundling properly, while the filesystem stuff that
+// yargs does by default doesn't.
+// If we don't do this, the default --version will be
+// unable to report its own version when run outside
+// the source directory.
+const { version } = require("./package.json");
+
 const yargs = require("yargs");
 const { hideBin } = require("yargs/helpers");
 const argv = yargs(hideBin(process.argv)).version(
   "--version",
   "Show version number",
-  "0.10.1",
+  version,
 ).argv;
 
 const msg = argv.msg;

--- a/axolotlsay-js/index.js
+++ b/axolotlsay-js/index.js
@@ -5,7 +5,7 @@ const { hideBin } = require("yargs/helpers");
 const argv = yargs(hideBin(process.argv)).version(
   "--version",
   "Show version number",
-  "0.10.0",
+  "0.10.1",
 ).argv;
 
 const msg = argv.msg;

--- a/axolotlsay-js/package-lock.json
+++ b/axolotlsay-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axolotlsay",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "axolotlsay",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT-or-Apache2.0",
       "dependencies": {
         "yargs": "^17.7.2"

--- a/axolotlsay-js/package-lock.json
+++ b/axolotlsay-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axolotlsay",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "axolotlsay",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT-or-Apache2.0",
       "dependencies": {
         "yargs": "^17.7.2"

--- a/axolotlsay-js/package.json
+++ b/axolotlsay-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axolotlsay",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "> 📄 a template for axodotdev's open source repositories",
   "main": "index.js",
   "bin": {

--- a/axolotlsay-js/package.json
+++ b/axolotlsay-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axolotlsay",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "> 📄 a template for axodotdev's open source repositories",
   "main": "index.js",
   "bin": {

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "axolotlsay"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "axolotlsay"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/crates/axolotlsay/Cargo.toml
+++ b/crates/axolotlsay/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axolotlsay"
 description = "💬 a CLI for learning to distribute CLIs in rust"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/axolotlsay-hybrid"

--- a/crates/axolotlsay/Cargo.toml
+++ b/crates/axolotlsay/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axolotlsay"
 description = "💬 a CLI for learning to distribute CLIs in rust"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/axolotlsay-hybrid"


### PR DESCRIPTION
When built with bun, the version can be displayed correctly if the binary is run inside the source directory and returns `unknown` otherwise.